### PR TITLE
Fix sign in button visibility in light theme

### DIFF
--- a/components/header.tsx
+++ b/components/header.tsx
@@ -64,8 +64,8 @@ export function Header() {
               <Dialog>
                 <DialogTrigger asChild>
                   <Button 
-                    variant="outline"
-                    className="relative group"
+                    variant="secondary"
+                    className="relative group border border-input hover:border-primary"
                   >
                     <div className="absolute inset-0 bg-gradient-to-r from-purple-500 to-blue-500 opacity-0 group-hover:opacity-20 transition-opacity rounded-md" />
                     <span>Sign In</span>


### PR DESCRIPTION
This PR improves the visibility of the sign-in button in light theme by:

- Changing button variant from "outline" to "secondary" for better contrast
- Adding a border that highlights on hover
- Maintaining the gradient hover effect with improved visibility

These changes make the button more visible while maintaining consistency with the UI design.